### PR TITLE
Further separation of concerns between Sensor and SensorReading.

### DIFF
--- a/schemas/sensorReadingSchema.json
+++ b/schemas/sensorReadingSchema.json
@@ -1,18 +1,12 @@
 {
-    "title": "Sensor",
-    "description": "A sensor within the RLES.",
+    "title": "Sensor Reading",
+    "description": "A sensor reading within the RLES.",
     "type": "object",
     "properties": {
         "sensorId": {
             "description": "The unique identifier for a sensor.",
             "type": "integer",
             "minimum": 0
-        },
-        "sensorName": {
-            "description": "The name of the sensor.",
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 64
         },
         "timestamp": {
             "description": "The time the reading was taken. (Epoch ms)",

--- a/simulator/src/main/java/com/rles/simulator/datastructures/CircularBuffer.java
+++ b/simulator/src/main/java/com/rles/simulator/datastructures/CircularBuffer.java
@@ -1,0 +1,67 @@
+package com.rles.simulator.datastructures;
+
+// A simple generic circular buffer to store the last N records
+// If the buffer is full, overwrite the oldest element.
+public class CircularBuffer<T> {
+
+	private final Object[] buffer;
+	
+	// Number of elements in the buffer
+	private int size = 0;
+	
+	// Pointers to head and tail of array
+	private int head = 0;
+	private int tail = 0;
+	
+	// Create a CircularBuffer of a set capacity
+	public CircularBuffer(int capacity) {
+		if (capacity <= 0) {
+			throw new IllegalArgumentException("Capacity must be non-negative or greater than 0.");
+		}
+		buffer = new Object[capacity];
+	}
+	
+
+	// Add an element and overwrite if the buffer is full
+	public void add(T element) {
+		buffer[tail] = element;
+		tail = (tail + 1) % buffer.length;
+		
+		// If the current size has reached our buffer length
+		if (size == buffer.length) {
+			// Push the head forward (causing the oldest record to drop).
+			head = (head + 1) % buffer.length;
+		} else {
+			// Otherwise, increment size.
+			size++;
+		}
+	}
+	
+	// Get record by oldest (head)
+	@SuppressWarnings("unchecked")
+	public T getOldest(int index) {
+		if (index < 0 || index >= size) {
+			throw new IndexOutOfBoundsException("Index of " + index + ", falls outside current size " + size);
+		}
+		
+		return (T) buffer[(head+index) % buffer.length];
+	}
+	
+	// Get record by newest (tail)
+	@SuppressWarnings("unchecked")
+	public T getNewest(int index) {
+		if (index < 0 || index >= size) {
+			throw new IndexOutOfBoundsException("Index of " + index + ", falls outside current size " + size);
+		}
+		// Tail points to next write position so newest element is at "tail - 1 - index".
+		// Likewise, if tail is at the beginning, we can go negative.
+		// Adding buffer.length guarantees a positive number.
+		return (T) buffer[(tail - 1 - index + buffer.length) % buffer.length];
+	}
+	
+	public int size() { return size; }
+	public int capacity() { return buffer.length; }
+	public boolean isFull() { return size == buffer.length; }
+	public boolean isEmpty() { return size == 0; }
+	
+}

--- a/simulator/src/main/java/com/rles/simulator/sensors/ReadingGenerator.java
+++ b/simulator/src/main/java/com/rles/simulator/sensors/ReadingGenerator.java
@@ -4,7 +4,10 @@ import java.util.Random;
 
 /*
  * ReadingGenerator - Used for generating sensor readings based on the measurement type.
- * 
+ * Think of this related more so to the simulator than to either the Sensor or SensorReading classes.
+ * By pushing for a class separate from the SensorReading class, it keeps the SensorReading just for describing what should be in a sensor's data.
+ * The ReadingGenerator will create different generations based on measurement types.
+ * I don't think this warrants a Strategy design pattern as I believe I can get away with just using one method with a parameter. (Subject to change I might use Strategy...)
  */
 
 public class ReadingGenerator {

--- a/simulator/src/main/java/com/rles/simulator/sensors/SensorReading.java
+++ b/simulator/src/main/java/com/rles/simulator/sensors/SensorReading.java
@@ -9,7 +9,7 @@ public class SensorReading{
 	private final long timestamp;
 	private final int sequence;
 	private final double value;
-	private ReadingStatus readingStatus;
+	private final ReadingStatus readingStatus;
 	
 	public SensorReading(int sensorId, long timestamp, int sequence, double value, ReadingStatus readingStatus) {
 		this.sensorId = sensorId;


### PR DESCRIPTION
Removed measurement type and unit code declarations from SensorReading. Sensor should not change to different measurement type or unit code over the course of its life. Therefore, a reading will always be that of the Sensor it pertains to. Likewise, the schema has been updated to reflect the sensor reading.

Furthermore, added a generic circular buffer class to be used in keeping recent readings in memory during runtime. This will help in future builds where data will be plotted since IO syscall interactions are slower than memory access.