### PR TITLE
Separate transport into a client and server version.

### DIFF
--- a/simulator/src/main/java/com/rles/simulator/Simulator.java
+++ b/simulator/src/main/java/com/rles/simulator/Simulator.java
@@ -52,7 +52,7 @@ public class Simulator {
 		}
 	}
 	
-	// Connect to transport and start stream (if needed), then schdule all sensors
+	// Connect to transport and start stream (if needed), then schedule all sensors
 	public synchronized void start() throws IOException {
 		if (running) return;
 		

--- a/simulator/src/main/java/com/rles/simulator/SimulatorMain.java
+++ b/simulator/src/main/java/com/rles/simulator/SimulatorMain.java
@@ -1,13 +1,17 @@
 package com.rles.simulator;
 
 import java.io.IOException;
-import java.util.Map;
 
 import com.rles.simulator.sensors.Sensor;
+import com.rles.simulator.sensors.environment.AmbientHumiditySensor;
 import com.rles.simulator.sensors.environment.AmbientTemperatureSensor;
+import com.rles.simulator.sensors.environment.DewPointSensor;
 import com.rles.simulator.telemetry.Encoder;
 import com.rles.simulator.telemetry.Streamer;
 import com.rles.simulator.telemetry.Transport;
+import com.rles.simulator.telemetry.ClientTransport;
+import com.rles.simulator.telemetry.ServerTransport;
+
 
 public class SimulatorMain {
 
@@ -15,21 +19,27 @@ public class SimulatorMain {
 		// Args pull
 		final String host = (args.length >= 1) ? args[0] : "127.0.0.1";
 		final int port = (args.length >= 2) ? Integer.parseInt(args[1]) : 7000;
-		final Simulator.OutputMode mode = (args.length >= 3) ? Simulator.OutputMode.valueOf(args[2].toUpperCase()) : Simulator.OutputMode.STREAM;
+		final Simulator.OutputMode mode = (args.length >= 3) ? Simulator.OutputMode.valueOf(args[2].toUpperCase()) : Simulator.OutputMode.BOTH;
 		
 		// Set-up
 		SimulatorContext context = new SimulatorContext();
-		Transport transport = new Transport(host, port);
+		//Transport transport = new ClientTransport(host, port);
+		Transport transport = new ServerTransport(port);
 		Encoder encoder = new Encoder();
 		Streamer streamer = new Streamer(encoder, transport, 1024, 64, 20);
 		Simulator sim = new Simulator(context, streamer, transport, mode);
 		
 		// Create sensors
 		Sensor temp = new AmbientTemperatureSensor(1001, "Ambient Temp", 1);
+		Sensor dew = new DewPointSensor(1002, "Dew Point", 1);
+		Sensor humidity = new AmbientHumiditySensor(1003, "Relative Humidity", 5, context, temp.getSensorId(), dew.getSensorId());
+		
 		
 		
 		// Register sensors
-		sim.registerSensor(temp, 200);
+		sim.registerSensor(temp, 100);
+		sim.registerSensor(dew, 100);
+		sim.registerSensor(humidity, 100);
 		
 		try {
 			sim.start();

--- a/simulator/src/main/java/com/rles/simulator/sensors/environment/AmbientHumiditySensor.java
+++ b/simulator/src/main/java/com/rles/simulator/sensors/environment/AmbientHumiditySensor.java
@@ -28,38 +28,41 @@ public class AmbientHumiditySensor extends Sensor {
 	private final ReadingGenerator gen;
 	private Double lastValue = null;
 	private int sequence = 0;
-	private SimulatorContext context;
-	private Sensor temperatureSensor;
-	private Sensor dewpointSensor;
+	private final SimulatorContext context;
+	private final Integer tempSensorId;
+	private final Integer dewpointSensorId;
 	
 	// Constructors
-	public AmbientHumiditySensor(int sensorId, String sensorName, int unitCode, SimulatorContext context) {
+	public AmbientHumiditySensor(int sensorId, String sensorName, int unitCode) {
+		super(sensorId, sensorName, DataType.FLOAT, unitCode);
+		this.gen = new ReadingGenerator();
+		this.context = null;
+		this.tempSensorId = null;
+		this.dewpointSensorId = null;
+	}
+	
+	public AmbientHumiditySensor(int sensorId, String sensorName, int unitCode, SimulatorContext context, Integer tempSensorId, Integer dewpointSensorId) {
 		super(sensorId, sensorName, DataType.FLOAT, unitCode);
 		this.gen = new ReadingGenerator();
 		this.context = context;
+		this.tempSensorId = tempSensorId;
+		this.dewpointSensorId = dewpointSensorId;
 	}
 	
-	public AmbientHumiditySensor(int sensorId, String sensorName, int unitCode, SimulatorContext context, long seed) {
+	public AmbientHumiditySensor(int sensorId, String sensorName, int unitCode, SimulatorContext context, Integer tempSensorId, Integer dewpointSensorId, long seed) {
 		super(sensorId, sensorName, DataType.FLOAT, unitCode);
 		this.gen = new ReadingGenerator(seed);
 		this.context = context;
+		this.tempSensorId = tempSensorId;
+		this.dewpointSensorId = dewpointSensorId;
 	}
-	
-	// Methods
-	public void linkTemperatureSensor(Sensor temperatureSensor) {
-		this.temperatureSensor = temperatureSensor;
-	}
-	
-	public void linkDewPointSensor(Sensor dewpointSensor) {
-		this.dewpointSensor = dewpointSensor;
-	}
-	
+		
 
 	// Generate our AmbientHumidity reading using the simulator context
 	@Override
 	public SensorReading generateReading() {
 		double value;
-		if (temperatureSensor == null || dewpointSensor == null) {
+		if (tempSensorId == null || dewpointSensorId == null || context == null) {
 			double base;
 			if (lastValue == null) {
 				base = gen.uniform(10.0, 15.0);
@@ -71,8 +74,8 @@ public class AmbientHumiditySensor extends Sensor {
 			lastValue = value;
 		}
 		else {
-			double temp = context.getLatest(temperatureSensor.getSensorId()).getValue();
-			double dewpoint = context.getLatest(dewpointSensor.getSensorId()).getValue();
+			double temp = context.getLatest(tempSensorId).getValue();
+			double dewpoint = context.getLatest(dewpointSensorId).getValue();
 			
 			// These calculations come from the University of Miami: https://bmcnoldy.earth.miami.edu/Humidity.html
 			// where they use approximations of Magnus coefficients in their relative humidity equation

--- a/simulator/src/main/java/com/rles/simulator/telemetry/ClientTransport.java
+++ b/simulator/src/main/java/com/rles/simulator/telemetry/ClientTransport.java
@@ -1,0 +1,92 @@
+package com.rles.simulator.telemetry;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+// CLIENT Transport - Pushes frames to a specific server (DEFAULT: 127.0.0.1)
+public class ClientTransport implements Transport {
+	
+	private final String host;
+	private final int port;
+	private final int timeoutMs;
+	private final int bufferSize;
+	
+	private Socket socket;
+	private BufferedOutputStream stream;
+	private volatile boolean connected;
+
+	// Default Constructor - localhost:7000, 5000ms timeout, 16kb buff
+	public ClientTransport() {
+		this("127.0.0.1", 7000, 5000, 16 * 1024);
+	}
+	
+	// 5000ms timeout, 16kb buff
+	public ClientTransport(String host, int port) {
+		this(host, port, 5000, 16 * 1024);
+	}
+	
+	public ClientTransport(String host, int port, int timeoutMs, int bufferSize) {
+		this.host = host;
+		this.port = port;
+		this.timeoutMs = timeoutMs;
+		this.bufferSize = bufferSize;
+	}
+	
+	// Establish a connection
+	public synchronized void connect() throws IOException {
+		if (connected) return;
+		// Create and connect to socket
+		socket = new Socket();
+		socket.connect(new InetSocketAddress(host,port), timeoutMs);
+		socket.setTcpNoDelay(true);
+		stream = new BufferedOutputStream(socket.getOutputStream(), bufferSize);
+		connected = true;
+	}
+	
+	// Send a frame of bytes to the destination
+	public synchronized void send(byte[] frame) throws IOException {
+		ensureConnected(); 
+		// If connected, write frame to stream
+		stream.write(frame);
+	}
+	
+	// Force write any in-buffer data
+	public synchronized void flush() throws IOException {
+		if (!connected) return;
+		stream.flush();
+	}
+	
+	// Close the connection
+	public synchronized void close() {
+		try {
+			// If we have a current stream, try flushing and closing
+			if (stream != null) {
+				try { 
+					stream.flush(); 
+				} catch (IOException e) {}
+				try {
+					stream.close();
+				} catch (IOException e) {}
+			}
+		} finally {
+			// Set stream and socket to null
+			stream = null;
+			if (socket != null) {
+				try {
+					socket.close();
+				} catch (IOException e) {}
+			}
+			socket = null;
+			connected = false;
+		}
+	}
+	
+	private void ensureConnected() throws IOException {
+		if (!connected || socket == null || stream == null) {
+			throw new IOException("Transport layer not connected");
+		}
+	}
+	
+}

--- a/simulator/src/main/java/com/rles/simulator/telemetry/Encoder.java
+++ b/simulator/src/main/java/com/rles/simulator/telemetry/Encoder.java
@@ -86,7 +86,7 @@ public class Encoder {
 	
 	// Get current version of the frame schema
 	public String getVersion() {
-		return this.VERSION;
+		return Encoder.VERSION;
 	}
 	
 }

--- a/simulator/src/main/java/com/rles/simulator/telemetry/ServerTransport.java
+++ b/simulator/src/main/java/com/rles/simulator/telemetry/ServerTransport.java
@@ -1,0 +1,143 @@
+package com.rles.simulator.telemetry;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+// SERVER Transport - Streams frames to all connected clients
+public class ServerTransport implements Transport{
+	
+	private final int port;
+	private final int bufferSize;
+	
+	private ServerSocket server;
+	private Thread acceptor;
+	private volatile boolean running;
+	
+	private final Set<Client> clients = Collections.synchronizedSet(new HashSet<>());
+	
+	public ServerTransport() { 
+		this(7000, 16*1024); 
+	}
+	
+	public ServerTransport(int port) { 
+		this(port, 16*1024);
+	}
+	
+	public ServerTransport(int port, int bufferSize) {
+		this.port = port;
+		this.bufferSize = bufferSize;
+	}
+	
+	@Override
+	public synchronized void connect() throws IOException {
+		if (running) return;
+		server = new ServerSocket(port);
+		running = true;
+		acceptor = new Thread(this::acceptLoop, "server-transport-acceptor");
+		acceptor.setDaemon(true);
+		acceptor.start();
+		System.out.println("[ServerTransport] Listening on: " + port);
+	}
+	
+	private void acceptLoop() {
+		while (running) {
+			try {
+				Socket s = server.accept();
+				s.setTcpNoDelay(true);
+				Client c = new Client(s, new BufferedOutputStream(s.getOutputStream(), bufferSize));
+				clients.add(c);
+				System.out.println("[ServerTransport] Client connected: " + s.getRemoteSocketAddress());
+			} catch (IOException e) {
+				if (running) {
+					System.err.println("[ServerTransport] Accept error: " + e.getMessage());
+				}
+			}
+		}
+	}
+	
+	@Override
+	public void send(byte[] frame) throws IOException {
+		synchronized (clients) {
+			clients.removeIf(client -> {
+				try {
+					client.stream.write(frame);
+					return false;
+				} catch (IOException e) {
+					dropClient(client);
+					return true;
+				}
+			});
+		}
+	}
+	
+	@Override
+	public void flush() throws IOException {
+		synchronized (clients) {
+			clients.removeIf(client -> {
+				try {
+					client.stream.flush();
+					return false;
+				} catch (IOException e) {
+					dropClient(client);
+					return true;
+				}
+			});
+		}
+	}
+	
+	// Teardown server transport
+	@Override
+	public synchronized void close() {
+		running = false;
+		try {
+			if (server != null)
+				server.close();
+		} catch (IOException e) {}
+		if (acceptor != null) {
+			try {
+				acceptor.join(1000);
+			} catch (InterruptedException e) {}
+		}
+		synchronized (clients) {
+			for (Client client : clients)
+				forceClose(client);
+			clients.clear();
+		}
+		server = null;
+		acceptor = null;
+		System.out.println("[ServerTransport] Terminated.");
+	}
+	
+	private void dropClient(Client client) {
+		System.err.println("[ServerTransport] Dropping client: " + client.sock.getRemoteSocketAddress());
+		forceClose(client);
+	}
+	
+	private void forceClose(Client client) {
+		try {
+			client.stream.flush();
+		} catch (IOException e) {}
+		try {
+			client.stream.close();
+		} catch (IOException e) {}
+		try {
+			client.sock.close();
+		} catch (IOException e) {}
+	}
+	
+	
+	private static final class Client {
+		final Socket sock;
+		final BufferedOutputStream stream;
+		Client(Socket s, BufferedOutputStream stream) {
+			this.sock = s;
+			this.stream = stream;
+		}
+	}
+	
+}


### PR DESCRIPTION
Separated concerns of transport into distinct client and server versions. That way it gives more flexibility later by being able to either listen to a port or query the server.

Smaller details:
- Used the SimulatorContext appropriately in the humidity sensor
- Fixed the Encoder accessor method to be of static reference instead of _this_
- Created a Transport interface for the Client and Server transports to contractually implement
