### PR TITLE
Add UnitCode representation to Sensors.

### DIFF
--- a/simulator/src/main/java/com/rles/simulator/Simulator.java
+++ b/simulator/src/main/java/com/rles/simulator/Simulator.java
@@ -73,13 +73,14 @@ public class Simulator {
 						// LOG
 						if (outputMode == OutputMode.LOG || outputMode == OutputMode.BOTH) {
 							System.out.printf(
-								"[Log] %s | Sensor %d | Seq %d | Time %d | Status=%s | Value=%.3f%n",
+								"[Log] %s | Sensor %d | Seq %d | Time %d | Status=%s | Value=%.3f%s%n",
 								rs.sensor.getSensorName(),
 								r.getSensorId(),
 								r.getSequence(),
 								r.getTimestamp(),
 								r.getReadingStatus(),
-								r.getValue()
+								r.getValue(),
+								r.getUnitCodeSymbol()
 							);
 						}
 						

--- a/simulator/src/main/java/com/rles/simulator/enums/UnitCode.java
+++ b/simulator/src/main/java/com/rles/simulator/enums/UnitCode.java
@@ -2,33 +2,33 @@ package com.rles.simulator.enums;
 
 // Represent unit codes as integers for byte frames
 public enum UnitCode {
-	NONE(0, ""),
-	PERCENT(1, "%"),
-	CELSIUS(2, "C"),
-	FAHRENHEIT(3, "F"),
-	KELVIN(4, "K"),
-	DEGREE(5, "Degree"),
-	METER(6, "m"),
-	METER_PER_SECOND(7, "m/s"),
-	AMP(8, "A"),
-	VOLT(9, "V"),
-	PASCAL(10, "Pa"),
-	CUBIC_METER_PER_SECOND(11, "m3/s"),
-	KILOGRAM_PER_SECOND(12, "kg/s"),
-	BOOLEAN(13, "bool");
+	NONE((byte)0, ""),
+	PERCENT((byte)1, "%"),
+	CELSIUS((byte)2, "C"),
+	FAHRENHEIT((byte)3, "F"),
+	KELVIN((byte)4, "K"),
+	DEGREE((byte)5, "Degree"),
+	METER((byte)6, "m"),
+	METER_PER_SECOND((byte)7, "m/s"),
+	AMP((byte)8, "A"),
+	VOLT((byte)9, "V"),
+	PASCAL((byte)10, "Pa"),
+	CUBIC_METER_PER_SECOND((byte)11, "m3/s"),
+	KILOGRAM_PER_SECOND((byte)12, "kg/s"),
+	BOOLEAN((byte)13, "bool");
 	
-	private final int code;
+	private final byte code;
 	private final String symbol;
 	
-	UnitCode(int code, String symbol) {
+	UnitCode(byte code, String symbol) {
 		this.code = code;
 		this.symbol = symbol;
 	}
 	
-	public int getCode() { return code; }
+	public byte getCode() { return code; }
 	public String getSymbol() { return symbol; }
 	
-	public static UnitCode getUnitCode(int code) {
+	public static UnitCode getUnitCode(byte code) {
 		for (UnitCode u : values()) {
 			if (u.code == code) return u;
 		}

--- a/simulator/src/main/java/com/rles/simulator/sensors/SensorReading.java
+++ b/simulator/src/main/java/com/rles/simulator/sensors/SensorReading.java
@@ -1,6 +1,7 @@
 package com.rles.simulator.sensors;
 
 import com.rles.simulator.enums.ReadingStatus;
+import com.rles.simulator.enums.UnitCode;
 
 // Represents a reading from a sensor
 public class SensorReading{
@@ -9,13 +10,15 @@ public class SensorReading{
 	private final long timestamp;
 	private final int sequence;
 	private final double value;
+	private final UnitCode unitCode;
 	private final ReadingStatus readingStatus;
 	
-	public SensorReading(int sensorId, long timestamp, int sequence, double value, ReadingStatus readingStatus) {
+	public SensorReading(int sensorId, long timestamp, int sequence, double value, UnitCode unitCode, ReadingStatus readingStatus) {
 		this.sensorId = sensorId;
 		this.timestamp = timestamp;
 		this.sequence = sequence;
 		this.value = value;
+		this.unitCode = unitCode;
 		this.readingStatus = readingStatus;
 	}
 	
@@ -24,7 +27,10 @@ public class SensorReading{
 	public long getTimestamp() { return timestamp; }
 	public int getSequence() { return sequence; }
 	public double getValue() { return value; }
+	public UnitCode getUnitCode() { return unitCode; }
+	public byte getUnitCodeByte() { return unitCode.getCode(); }
+	public String getUnitCodeSymbol() { return unitCode.getSymbol(); }
 	public ReadingStatus getReadingStatus() { return readingStatus; }
-	public byte getStatusCode() { return readingStatus.getCode(); }
+	public byte getStatusByte() { return readingStatus.getCode(); }
 	
 }

--- a/simulator/src/main/java/com/rles/simulator/sensors/environment/AmbientHumiditySensor.java
+++ b/simulator/src/main/java/com/rles/simulator/sensors/environment/AmbientHumiditySensor.java
@@ -3,6 +3,7 @@ package com.rles.simulator.sensors.environment;
 import com.rles.simulator.SimulatorContext;
 import com.rles.simulator.enums.DataType;
 import com.rles.simulator.enums.ReadingStatus;
+import com.rles.simulator.enums.UnitCode;
 import com.rles.simulator.sensors.ReadingGenerator;
 import com.rles.simulator.sensors.Sensor;
 import com.rles.simulator.sensors.SensorReading;
@@ -90,7 +91,9 @@ public class AmbientHumiditySensor extends Sensor {
 		if (value >= WARN_THRESHOLD) status = ReadingStatus.WARN;
 		if (value >= FAULT_THRESHOLD) status = ReadingStatus.FAULT;	
 		
-		return new SensorReading(getSensorId(), System.currentTimeMillis(), sequence++, value, status);
+		UnitCode unitcode = UnitCode.PERCENT;
+		
+		return new SensorReading(getSensorId(), System.currentTimeMillis(), sequence++, value, unitcode , status);
 		
 	}
 

--- a/simulator/src/main/java/com/rles/simulator/sensors/environment/AmbientTemperatureSensor.java
+++ b/simulator/src/main/java/com/rles/simulator/sensors/environment/AmbientTemperatureSensor.java
@@ -2,6 +2,7 @@ package com.rles.simulator.sensors.environment;
 
 import com.rles.simulator.enums.DataType;
 import com.rles.simulator.enums.ReadingStatus;
+import com.rles.simulator.enums.UnitCode;
 import com.rles.simulator.sensors.ReadingGenerator;
 import com.rles.simulator.sensors.Sensor;
 import com.rles.simulator.sensors.SensorReading;
@@ -42,7 +43,9 @@ public class AmbientTemperatureSensor extends Sensor {
 		if (value >= WARN_THRESHOLD) status = ReadingStatus.WARN;
 		if (value >= FAULT_THRESHOLD) status = ReadingStatus.FAULT;
 		
-		return new SensorReading(getSensorId(), System.currentTimeMillis(), sequence++, value, status);
+		UnitCode unitcode = UnitCode.CELSIUS;
+		
+		return new SensorReading(getSensorId(), System.currentTimeMillis(), sequence++, value, unitcode, status);
 	}
 
 }

--- a/simulator/src/main/java/com/rles/simulator/sensors/environment/DewPointSensor.java
+++ b/simulator/src/main/java/com/rles/simulator/sensors/environment/DewPointSensor.java
@@ -2,6 +2,7 @@ package com.rles.simulator.sensors.environment;
 
 import com.rles.simulator.enums.DataType;
 import com.rles.simulator.enums.ReadingStatus;
+import com.rles.simulator.enums.UnitCode;
 import com.rles.simulator.sensors.ReadingGenerator;
 import com.rles.simulator.sensors.Sensor;
 import com.rles.simulator.sensors.SensorReading;
@@ -12,7 +13,7 @@ public class DewPointSensor extends Sensor {
 	private static final double MIN = -60.0; // Celsius
 	private static final double MAX = 100.0; // Celsius
 	private static final double GRAIN = 0.01;
-	private static final double MAX_STEP = 0.5;
+	private static final double MAX_STEP = 0.01;
 	private static final double NOISE_SIGMA = 0.2;
 	private static final double WARN_THRESHOLD = 50.0;
 	private static final double FAULT_THRESHOLD = 60.0;
@@ -31,7 +32,7 @@ public class DewPointSensor extends Sensor {
 	public SensorReading generateReading() {
 		double base;
 		if (lastValue == null) {
-			base = gen.uniform(10.0, 15.0);
+			base = gen.uniform(0.0, 5.0);
 		} else {
 			base = gen.randomWalkClamped(lastValue,  MAX_STEP,  MIN,  MAX);
 			base += gen.gaussian(0, NOISE_SIGMA);
@@ -43,7 +44,9 @@ public class DewPointSensor extends Sensor {
 		if (value >= WARN_THRESHOLD) status = ReadingStatus.WARN;
 		if (value >= FAULT_THRESHOLD) status = ReadingStatus.FAULT;
 		
-		return new SensorReading(getSensorId(), System.currentTimeMillis(), sequence++, value, status);
+		UnitCode unitcode = UnitCode.CELSIUS;
+		
+		return new SensorReading(getSensorId(), System.currentTimeMillis(), sequence++, value, unitcode, status);
 	}
 	
 }

--- a/simulator/src/main/java/com/rles/simulator/telemetry/Encoder.java
+++ b/simulator/src/main/java/com/rles/simulator/telemetry/Encoder.java
@@ -17,7 +17,7 @@ public class Encoder {
 	private static final byte FLAGS = 0x00;
 	
 	private static final int HEADER_SIZE = 8; // 2b-magic, 1b-version, 1b-flags, 4b-length
-	private static final int DATA_SIZE = 25; //4b-id, 8b-timestamp, 4b-sequence, 8b-value, 1b-status
+	private static final int DATA_SIZE = 26; //4b-id, 8b-timestamp, 4b-sequence, 8b-value, 1b-unit, 1b-status
 	private static final int CRC_SIZE = 4;
 	private static final int FRAME_SIZE = HEADER_SIZE + DATA_SIZE + CRC_SIZE;
 	
@@ -31,7 +31,8 @@ public class Encoder {
 	// timestamp - Long
 	// sequence - Integer
 	// value - Double
-	// status - Byte (ReadingStatus code)
+	// unit code - Byte (UnitCode)
+	// status - Byte (ReadingStatus)
 	public byte[] encode(SensorReading reading) {
 		ByteBuffer buf = ByteBuffer.allocate(FRAME_SIZE).order(ByteOrder.LITTLE_ENDIAN);
 		
@@ -47,7 +48,8 @@ public class Encoder {
 		buf.putLong(reading.getTimestamp());
 		buf.putInt(reading.getSequence());
 		buf.putDouble(reading.getValue());
-		buf.put(reading.getStatusCode());
+		buf.put(reading.getUnitCodeByte());
+		buf.put(reading.getStatusByte());
 		
 		// Cyclic Redundancy Check
 		byte[] arr = buf.array();


### PR DESCRIPTION
- Added byte representation to the UnitCode enum
- Added unit code to our sensor reading frame in Encoder (occupies 1 byte)
- Added unit codes to all implemented sensor reading generators
- Added unit code values to the verbose/pretty print LOG output in Simulator