### PR TITLE
Remove unit code from Sensor class and only store in SensorReading.

### DIFF
--- a/simulator/src/main/java/com/rles/simulator/SimulatorMain.java
+++ b/simulator/src/main/java/com/rles/simulator/SimulatorMain.java
@@ -30,9 +30,9 @@ public class SimulatorMain {
 		Simulator sim = new Simulator(context, streamer, transport, mode);
 		
 		// Create sensors
-		Sensor temp = new AmbientTemperatureSensor(1001, "Ambient Temp", 1);
-		Sensor dew = new DewPointSensor(1002, "Dew Point", 1);
-		Sensor humidity = new AmbientHumiditySensor(1003, "Relative Humidity", 5, context, temp.getSensorId(), dew.getSensorId());
+		Sensor temp = new AmbientTemperatureSensor(1001, "Ambient Temp");
+		Sensor dew = new DewPointSensor(1002, "Dew Point");
+		Sensor humidity = new AmbientHumiditySensor(1003, "Relative Humidity", context, temp.getSensorId(), dew.getSensorId());
 		
 		
 		

--- a/simulator/src/main/java/com/rles/simulator/sensors/Sensor.java
+++ b/simulator/src/main/java/com/rles/simulator/sensors/Sensor.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.rles.simulator.datastructures.CircularBuffer;
 import com.rles.simulator.enums.DataType;
 import com.rles.simulator.enums.DeviceStatus;
+import com.rles.simulator.enums.UnitCode;
 
 // This class will represent the base class for all sensors.
 public abstract class Sensor {
@@ -13,32 +14,30 @@ public abstract class Sensor {
 	private final int sensorId;	
 	private String sensorName;
 	private final DataType measurementType;
-	private final int unitCode;
 	private DeviceStatus deviceStatus;
 	private final CircularBuffer<SensorReading> history;
 	// TODO: Move magic numbers into config.
 	private static final int HISTORY_CAPACITY = 256;
 	
 	// Constructor uses default capacity for buffer
-	public Sensor(int sensorId, String sensorName, DataType measurementType, int unitCode) {
-		this(sensorId, sensorName, measurementType, unitCode, HISTORY_CAPACITY);
+	public Sensor(int sensorId, String sensorName, DataType measurementType) {
+		this(sensorId, sensorName, measurementType, HISTORY_CAPACITY);
 	}
 	
 	// Constructor uses parameter capacity for buffer
-	public Sensor(int sensorId, String sensorName, DataType measurementType, int unitCode, int historyCapacity) {
+	public Sensor(int sensorId, String sensorName, DataType measurementType, int historyCapacity) {
 		this.sensorId = sensorId;
 		this.sensorName = sensorName;
 		this.measurementType = measurementType;
-		this.unitCode = unitCode;
 		this.deviceStatus = DeviceStatus.ACTIVE;
 		this.history = new CircularBuffer<SensorReading>(historyCapacity);
 	}
+	
 	
 	// Accessor methods
 	public int getSensorId() { return sensorId; }
 	public String getSensorName() { return sensorName; }
 	public DataType getMeasurementType() { return measurementType; }
-	public int getUnitCode() { return unitCode; }
 	public DeviceStatus getDeviceStatus() { return deviceStatus; }
 	
 	// Mutator methods

--- a/simulator/src/main/java/com/rles/simulator/sensors/environment/AmbientHumiditySensor.java
+++ b/simulator/src/main/java/com/rles/simulator/sensors/environment/AmbientHumiditySensor.java
@@ -34,24 +34,24 @@ public class AmbientHumiditySensor extends Sensor {
 	private final Integer dewpointSensorId;
 	
 	// Constructors
-	public AmbientHumiditySensor(int sensorId, String sensorName, int unitCode) {
-		super(sensorId, sensorName, DataType.FLOAT, unitCode);
+	public AmbientHumiditySensor(int sensorId, String sensorName) {
+		super(sensorId, sensorName, DataType.FLOAT);
 		this.gen = new ReadingGenerator();
 		this.context = null;
 		this.tempSensorId = null;
 		this.dewpointSensorId = null;
 	}
 	
-	public AmbientHumiditySensor(int sensorId, String sensorName, int unitCode, SimulatorContext context, Integer tempSensorId, Integer dewpointSensorId) {
-		super(sensorId, sensorName, DataType.FLOAT, unitCode);
+	public AmbientHumiditySensor(int sensorId, String sensorName, SimulatorContext context, Integer tempSensorId, Integer dewpointSensorId) {
+		super(sensorId, sensorName, DataType.FLOAT);
 		this.gen = new ReadingGenerator();
 		this.context = context;
 		this.tempSensorId = tempSensorId;
 		this.dewpointSensorId = dewpointSensorId;
 	}
 	
-	public AmbientHumiditySensor(int sensorId, String sensorName, int unitCode, SimulatorContext context, Integer tempSensorId, Integer dewpointSensorId, long seed) {
-		super(sensorId, sensorName, DataType.FLOAT, unitCode);
+	public AmbientHumiditySensor(int sensorId, String sensorName, SimulatorContext context, Integer tempSensorId, Integer dewpointSensorId, long seed) {
+		super(sensorId, sensorName, DataType.FLOAT);
 		this.gen = new ReadingGenerator(seed);
 		this.context = context;
 		this.tempSensorId = tempSensorId;
@@ -66,7 +66,7 @@ public class AmbientHumiditySensor extends Sensor {
 		if (tempSensorId == null || dewpointSensorId == null || context == null) {
 			double base;
 			if (lastValue == null) {
-				base = gen.uniform(10.0, 15.0);
+				base = gen.uniform(20, 30.0);
 			} else {
 				base = gen.randomWalkClamped(lastValue,  MAX_STEP,  MIN,  MAX);
 				base += gen.gaussian(0, NOISE_SIGMA);

--- a/simulator/src/main/java/com/rles/simulator/sensors/environment/AmbientTemperatureSensor.java
+++ b/simulator/src/main/java/com/rles/simulator/sensors/environment/AmbientTemperatureSensor.java
@@ -22,8 +22,8 @@ public class AmbientTemperatureSensor extends Sensor {
 	private Double lastValue = null;
 	private int sequence = 0;
 
-	public AmbientTemperatureSensor(int sensorId, String sensorName, int unitCode) {
-		super(sensorId, sensorName, DataType.FLOAT, unitCode);
+	public AmbientTemperatureSensor(int sensorId, String sensorName) {
+		super(sensorId, sensorName, DataType.FLOAT);
 		this.gen = new ReadingGenerator();
 	}
 

--- a/simulator/src/main/java/com/rles/simulator/sensors/environment/DewPointSensor.java
+++ b/simulator/src/main/java/com/rles/simulator/sensors/environment/DewPointSensor.java
@@ -23,8 +23,8 @@ public class DewPointSensor extends Sensor {
 	private Double lastValue = null;
 	private int sequence = 0;
 	
-	public DewPointSensor(int sensorId, String sensorName, int unitCode) {
-		super(sensorId, sensorName, DataType.FLOAT, unitCode);
+	public DewPointSensor(int sensorId, String sensorName) {
+		super(sensorId, sensorName, DataType.FLOAT);
 		this.gen = new ReadingGenerator();
 	}
 	


### PR DESCRIPTION
Removed the unit code instance variable from the Sensor abstract class. It does not make sense to have a unit code for a Sensor when the reading it has carries the unit. Furthermore, makes instantiation cleaner/shorter as you only need the sensor id and human readable name for default.